### PR TITLE
Merge errors within same group

### DIFF
--- a/YiiConditionalValidator.php
+++ b/YiiConditionalValidator.php
@@ -178,7 +178,8 @@ class YiiConditionalValidator extends CValidator
                 $object->clearErrors();
 
                 if (!$discardErrorsAfterCheck) {
-                    $object->addErrors($newErrors);
+                    // Merge new with 'existing' errors to prevent the last error within the same group (if/then) overwrite all others
+                    $object->addErrors(CMap::mergeArray($errorsBackup, $newErrors));
                 }
 
                 if ($returnFalseOnError) {


### PR DESCRIPTION
**Note:**
This code change is actually almost the same as [DrDeath72 wrote on 22 Sep 2014](https://github.com/sdlins/Yii-Conditional-Validator/pull/5#commitcomment-7870762) in PR #5 

If not merging the errors (on line 181/182), only the last message within a group is preserved.

For example:
```
 array('email', 'ext.validators.ConditionalValidator',
		'if' => array(
			array('last_name', 'compare', 'compareValue' => '')
		),
		'then' => array(
			array('email', 'required', 'message' => 'Special email message'),
			array('phone_number', 'required', 'message' => 'Special phone number message'),
		)
	),
```

Now gives two seperate error messages.
Before this change, only the last message, "Special phone number message" was preserved/shown.